### PR TITLE
Fix fallback to bitser when marshal not present in LÖVE 11.1

### DIFF
--- a/sync.lua
+++ b/sync.lua
@@ -9,8 +9,8 @@ local pairs, next, type = pairs, next, type
 
 local encode, decode -- Pick serialization functions
 do
-    local marshal = require 'marshal'
-    if marshal then
+    local hasMarshal, marshal = pcall(require, 'marshal')
+    if hasMarshal then
         encode, decode = marshal.encode, marshal.decode
     else
         local bitser = (function(s) return require(s) end)('bitser')


### PR DESCRIPTION
When using `sync.lua` in LÖVE 11.1, if `marshal` is not present, `require 'marshal'` calls `error` and causes LÖVE 11.1 to fail with

> Error
> 
> sync.lua:13: module 'marshal' not found:
> no field package.preload['marshal']
> no 'marshal' in LOVE game directories.
> no file 'marshal' in LOVE paths.
> no file '.\marshal.lua'
> no file 'C:\Program Files\Love\lua\marshal.lua'
> no file 'C:\Program Files\Love\lua\marshal\init.lua'
> no file '.\marshal.dll'
> no file 'C:\Program Files\Love\marshal.dll'
> no file 'C:\Program Files\Love\loadall.dll'
> 
> 
> Traceback
> 
> [C]: in function 'require'
> sync.lua:13: in main chunk
> [C]: in function 'require'
> main.lua:1: in main chunk
> [C]: in function 'require'
> [C]: in function 'xpcall'
> [C]: in function 'xpcall'

By calling require with `pcall`, what was probably the originally intended behavior happens instead, as the `error` is caught and we can check the flag that is returned.

I've tested this in LÖVE 11.1 and the latest version of Castle